### PR TITLE
Add meetup location commands

### DIFF
--- a/boardwhite/handlers.go
+++ b/boardwhite/handlers.go
@@ -42,6 +42,8 @@ func (s *Service) RegisterHandlers(ctx context.Context, registry tg.HandlerRegis
 	registry.RegisterHandler(tele.OnText, "OnOborona", withContext(ctx, s.OnOborona))
 	registry.RegisterHandler(tele.OnText, "OnUpdateOkr", withContext(ctx, s.OnUpdateOkr))
 	registry.RegisterHandler(tele.OnText, "OnRemoveOkr", withContext(ctx, s.OnRemoveOkr))
+	registry.RegisterHandler(tele.OnText, "OnMeetup", withContext(ctx, s.OnMeetup))
+	registry.RegisterHandler(tele.OnCallback, "OnMeetupCallback", withContext(ctx, s.OnMeetupCallback))
 }
 
 func withContext(ctx context.Context, f func(context.Context, tele.Context) error) tele.HandlerFunc {

--- a/boardwhite/meetup.go
+++ b/boardwhite/meetup.go
@@ -1,0 +1,152 @@
+package boardwhite
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/boar-d-white-foundation/drone/db"
+	"github.com/boar-d-white-foundation/drone/tg"
+	tele "gopkg.in/telebot.v3"
+)
+
+const meetupAddUnique = "meetup_add"
+
+type meetupStore map[string][]tele.User
+
+func addUserToMeetup(tx db.Tx, location string, user tele.User) error {
+	meetups, err := db.GetJsonDefault(tx, keyMeetupLocations, meetupStore{})
+	if err != nil {
+		return fmt.Errorf("get meetups: %w", err)
+	}
+	users := meetups[location]
+	if idx := slices.IndexFunc(users, func(u tele.User) bool { return u.ID == user.ID }); idx == -1 {
+		meetups[location] = append(users, user)
+	}
+	if err := db.SetJson(tx, keyMeetupLocations, meetups); err != nil {
+		return fmt.Errorf("set meetups: %w", err)
+	}
+	return nil
+}
+
+func listMeetupLocations(tx db.Tx) ([]string, error) {
+	meetups, err := db.GetJsonDefault(tx, keyMeetupLocations, meetupStore{})
+	if err != nil {
+		return nil, fmt.Errorf("get meetups: %w", err)
+	}
+	locations := make([]string, 0, len(meetups))
+	for loc := range meetups {
+		locations = append(locations, loc)
+	}
+	slices.Sort(locations)
+	return locations, nil
+}
+
+func (s *Service) OnMeetup(ctx context.Context, c tele.Context) error {
+	msg, chat := c.Message(), c.Chat()
+	if msg == nil || chat == nil || chat.ID != s.cfg.ChatID {
+		return nil
+	}
+	if !strings.HasPrefix(msg.Text, "/сходка") {
+		return nil
+	}
+
+	parts := strings.Fields(msg.Text)
+	if len(parts) < 2 || parts[1] == "list" {
+		return s.database.Do(ctx, func(tx db.Tx) error {
+			locations, err := listMeetupLocations(tx)
+			if err != nil {
+				return err
+			}
+			if len(locations) == 0 {
+				_, err = s.telegram.ReplyWithText(msg.ID, "Пока нет локаций")
+				return err
+			}
+			_, err = s.telegram.ReplyWithText(msg.ID, strings.Join(locations, "\n"))
+			return err
+		})
+	}
+	if parts[1] == "add" {
+		if len(parts) < 3 {
+			return s.database.Do(ctx, func(tx db.Tx) error {
+				meetups, err := db.GetJsonDefault(tx, keyMeetupLocations, meetupStore{})
+				if err != nil {
+					return fmt.Errorf("get meetups: %w", err)
+				}
+				if len(meetups) == 0 {
+					_, err = s.telegram.ReplyWithText(msg.ID, "Пока нет локаций, добавь новую через /сходка add {локация}")
+					return err
+				}
+				markup := &tele.ReplyMarkup{}
+				rows := make([]tele.Row, 0, len(meetups))
+				for loc := range meetups {
+					btn := markup.Data(loc, meetupAddUnique, loc)
+					rows = append(rows, markup.Row(btn))
+				}
+				markup.Inline(rows...)
+				_, err = s.telegram.SendTextWithMarkup(msg.ThreadID, "Выбери локацию", markup)
+				return err
+			})
+		}
+		location := strings.Join(parts[2:], " ")
+		if msg.Sender == nil {
+			return nil
+		}
+		err := s.database.Do(ctx, func(tx db.Tx) error {
+			return addUserToMeetup(tx, location, *msg.Sender)
+		})
+		if err != nil {
+			return err
+		}
+		mention := tg.BuildMentionMarkdownV2(*msg.Sender)
+		_, err = s.telegram.SendMarkdownV2(msg.ThreadID, fmt.Sprintf("%s добавлен в %s", mention, tg.EscapeMD(location)))
+		return err
+	}
+
+	location := strings.Join(parts[1:], " ")
+	return s.database.Do(ctx, func(tx db.Tx) error {
+		meetups, err := db.GetJsonDefault(tx, keyMeetupLocations, meetupStore{})
+		if err != nil {
+			return fmt.Errorf("get meetups: %w", err)
+		}
+		users := meetups[location]
+		if len(users) == 0 {
+			_, err = s.telegram.ReplyWithText(msg.ID, "В этой локации никого нет")
+			return err
+		}
+		mentions := make([]string, 0, len(users))
+		for _, u := range users {
+			mentions = append(mentions, tg.BuildMentionMarkdownV2(u))
+		}
+		text := strings.Join(mentions, " ")
+		_, err = s.telegram.SendMarkdownV2(msg.ThreadID, text)
+		return err
+	})
+}
+
+func (s *Service) OnMeetupCallback(ctx context.Context, c tele.Context) error {
+	cb, msg, chat := c.Callback(), c.Message(), c.Chat()
+	if cb == nil || msg == nil || chat == nil || chat.ID != s.cfg.ChatID {
+		return nil
+	}
+	if cb.Unique != meetupAddUnique {
+		return nil
+	}
+	if cb.Sender == nil {
+		return nil
+	}
+	location := cb.Data
+	err := s.database.Do(ctx, func(tx db.Tx) error {
+		return addUserToMeetup(tx, location, *cb.Sender)
+	})
+	if err != nil {
+		return err
+	}
+	mention := tg.BuildMentionMarkdownV2(*cb.Sender)
+	_, err = s.telegram.SendMarkdownV2(msg.ThreadID, fmt.Sprintf("%s добавлен в %s", mention, tg.EscapeMD(location)))
+	if err != nil {
+		return err
+	}
+	return c.Respond()
+}

--- a/boardwhite/meetup_test.go
+++ b/boardwhite/meetup_test.go
@@ -1,0 +1,77 @@
+package boardwhite
+
+import (
+	"context"
+	"testing"
+
+	"github.com/boar-d-white-foundation/drone/db"
+	"github.com/stretchr/testify/require"
+	tele "gopkg.in/telebot.v3"
+)
+
+func TestAddUserToMeetup(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	database := db.NewBadgerDB(":memory:")
+	err := database.Start(ctx)
+	require.NoError(t, err)
+	t.Cleanup(database.Stop)
+
+	user1 := tele.User{ID: 1, Username: "user1"}
+	user2 := tele.User{ID: 2, Username: "user2"}
+
+	err = database.Do(ctx, func(tx db.Tx) error {
+		return addUserToMeetup(tx, "park", user1)
+	})
+	require.NoError(t, err)
+
+	// adding same user again should not create duplicates
+	err = database.Do(ctx, func(tx db.Tx) error {
+		return addUserToMeetup(tx, "park", user1)
+	})
+	require.NoError(t, err)
+
+	// adding another user should append
+	err = database.Do(ctx, func(tx db.Tx) error {
+		return addUserToMeetup(tx, "park", user2)
+	})
+	require.NoError(t, err)
+
+	err = database.Do(ctx, func(tx db.Tx) error {
+		meetups, err := db.GetJsonDefault(tx, keyMeetupLocations, meetupStore{})
+		require.NoError(t, err)
+		users := meetups["park"]
+		require.Len(t, users, 2)
+		require.Equal(t, user1.ID, users[0].ID)
+		require.Equal(t, user2.ID, users[1].ID)
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+func TestListMeetupLocations(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	database := db.NewBadgerDB(":memory:")
+	err := database.Start(ctx)
+	require.NoError(t, err)
+	t.Cleanup(database.Stop)
+
+	err = database.Do(ctx, func(tx db.Tx) error {
+		if err := addUserToMeetup(tx, "park", tele.User{ID: 1}); err != nil {
+			return err
+		}
+		return addUserToMeetup(tx, "office", tele.User{ID: 2})
+	})
+	require.NoError(t, err)
+
+	var locations []string
+	err = database.Do(ctx, func(tx db.Tx) error {
+		locations, err = listMeetupLocations(tx)
+		return err
+	})
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"office", "park"}, locations)
+}

--- a/boardwhite/service.go
+++ b/boardwhite/service.go
@@ -36,6 +36,8 @@ const (
 
 	keyOkrValues        = "boardwhite:okr:values"
 	keyOkrPinnedMessage = "boardwhite:okr:pinned_message"
+
+	keyMeetupLocations = "boardwhite:meetup:locations"
 )
 
 var (

--- a/tg/service.go
+++ b/tg/service.go
@@ -21,6 +21,7 @@ type Client interface {
 	SendMonospace(threadID int, text string) (int, error)
 	SendMarkdownV2(threadID int, text string) (int, error)
 	SendText(threadID int, text string) (int, error)
+	SendTextWithMarkup(threadID int, text string, markup *tele.ReplyMarkup) (int, error)
 	SendSpoilerLink(threadID int, header, link string) (int, error)
 	SendSticker(threadID int, stickerID string) (int, error)
 	ReplyWithSticker(messageID int, stickerID string) (int, error)
@@ -236,6 +237,18 @@ func (s *Service) SendText(threadID int, text string) (int, error) {
 	})
 	if err != nil {
 		return 0, fmt.Errorf("send text %q: %w", text, err)
+	}
+
+	return message.ID, nil
+}
+
+func (s *Service) SendTextWithMarkup(threadID int, text string, markup *tele.ReplyMarkup) (int, error) {
+	message, err := s.bot.Send(s.chatID, text, &tele.SendOptions{
+		ThreadID:    threadID,
+		ReplyMarkup: markup,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("send text with markup %q: %w", text, err)
 	}
 
 	return message.ID, nil


### PR DESCRIPTION
## Summary
- track meetup participants per location in DB
- allow joining locations and tagging members with `/сходка`
- extend Telegram client to send messages with inline buttons
- show available meetup locations when `/сходка` used without arguments or with `list`
- test meetup user storage and location listing in DB

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bd33228eb483278ac3eaa32392d24b